### PR TITLE
CLI: Assign Defaults

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -3,7 +3,9 @@
 	<description>PHPCS rules for HM Utility Taxonomy</description>
 
 	<!-- Use HM Coding Standards -->
-	<rule ref="vendor/humanmade/coding-standards" />
+	<rule ref="vendor/humanmade/coding-standards">
+		<exclude name="HM.Files.NamespaceDirectoryName.NameMismatch" />
+	</rule>
 
 	<arg name="extensions" value="php" />
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Utility Taxonomy
+
 A hidden taxonomy, used for filtering of posts/pages etc. in a way that is more performant than using the likes of post meta.
 
 ## Usage
+
 A plugin or theme can add their options by adding the `hm-utility` taxonomy to desired post type(s) and registering the options:
 
 ```php
@@ -21,6 +23,7 @@ add_action( 'init, 'register_my_post_type' );
 ```
 
 To add support for built-in post types or other post types that you don't have control over their registration, use `hm_utility_init` hook:
+
 ```php
 /**
  * Add hm-utility taxonomy to `page` post type
@@ -75,3 +78,13 @@ add_filter( 'hm_utility_options', 'my_utility_options', 10, 2 );
 The block editor should now provide a Panel titled "Something Extra" on the Document sidebar that contains a list of checkboxes (or a toggle if there's only one option) based on the options registered above.
 
 It is up to the plugin or theme to use the automatically created terms to [filter their queries](https://developer.wordpress.org/reference/classes/wp_query/#taxonomy-parameters). See also [Tom J Nowell's post](https://tomjn.com/2018/03/16/utility-taxonomies/) for example use cases. It's actually the inspiration behind this plugin ;-)
+
+## CLI
+
+This plugin provides a WP CLI command to assign default terms on existing posts:
+
+```
+wp hm-utility-taxonomy assign-defaults
+```
+
+Pass `--help` to the command to see available options.

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -112,8 +112,14 @@ class Assign_Defaults_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp hm-utility-taxonomy assign-defaults --dry-run
-	 * wp hm-utility-taxonomy assign-defaults
+	 *     # Dry run
+	 *     $ wp hm-utility-taxonomy assign-defaults --dry-run
+	 *
+	 *     # Limit operation to pages only
+	 *     $ wp hm-utility-taxonomy assign-defaults --post_type=page
+	 *
+	 *     # Limit operation to draft posts & pages only
+	 *     $ wp hm-utility-taxonomy assign-defaults --post_type=page,post --post_status=draft
 	 *
 	 * @param array $args       Positional arguments passed to the command.
 	 * @param array $args_assoc Associative arguments passed to the command.

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -104,8 +104,11 @@ class Assign_Defaults_Command {
 	 * [--dry-run]
 	 * : Run the entire operation and show report, but don't save changes to the database.
 	 *
+	 * [--post_status=<post_statuses>]
+	 * : Limit post search to specific post statuses, separated by comma. Defaults to 'publish'.
+	 *
 	 * [--post_type=<post_types>]
-     * : Limit post search to specific post types, separated by comma.
+	 * : Limit post search to specific post types, separated by comma.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -140,6 +143,10 @@ class Assign_Defaults_Command {
 
 		if ( empty( $query_args['post_type'] ) ) {
 			WP_CLI::error( 'The specified post types are not supported by Utility Taxonomy.' );
+		}
+
+		if ( ! empty( $args_assoc['post_status'] ) ) {
+			$query_args['post_status'] = explode( ',', $args_assoc['post_status'] );
 		}
 
 		$query             = $this->get_query( $query_args );

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -63,15 +63,16 @@ class Assign_Defaults_Command {
 	/**
 	 * Get query
 	 *
+	 * @param array $args Array of query arguments to pass to WP_Query.
+	 *
 	 * @return WP_Query
 	 */
-	protected function get_query() : WP_Query {
-		$query_args = [
+	protected function get_query( array $args ) : WP_Query {
+		$query_args = wp_parse_args( $args, [
 			'paged'          => $this->paged,
 			'post_status'    => 'publish',
-			'post_type'      => 'post',
 			'posts_per_page' => $this->posts_per_page,
-		];
+		] );
 
 		$query = new WP_Query( $query_args );
 
@@ -128,8 +129,6 @@ class Assign_Defaults_Command {
 			$this->is_dry_running = true;
 		}
 
-		unset( $args_assoc['dry-run'] );
-
 		$query_args = [];
 
 		if ( isset( $args_assoc['post_type'] ) ) {
@@ -143,7 +142,7 @@ class Assign_Defaults_Command {
 			WP_CLI::error( 'The specified post types are not supported by Utility Taxonomy.' );
 		}
 
-		$query             = $this->get_query();
+		$query             = $this->get_query( $query_args );
 		$this->found_posts = absint( $query->found_posts );
 		$this->max_pages   = $query->max_num_pages;
 
@@ -163,7 +162,7 @@ class Assign_Defaults_Command {
 
 		do {
 			if ( $query->query_vars['paged'] !== $this->paged ) {
-				$query = $this->get_query();
+				$query = $this->get_query( $query_args );
 			}
 
 			array_walk( $query->posts, [ $this, 'process' ] );

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -103,6 +103,9 @@ class Assign_Defaults_Command {
 	 * [--dry-run]
 	 * : Run the entire operation and show report, but don't save changes to the database.
 	 *
+	 * [--post_type=<post_types>]
+     * : Limit post search to specific post types, separated by comma.
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp hm-utility-taxonomy assign-defaults --dry-run
@@ -118,7 +121,6 @@ class Assign_Defaults_Command {
 
 		if ( empty( $supported_post_types ) ) {
 			WP_CLI::error( 'No supported post types found.' );
-			return;
 		}
 
 		// Indicate that we're dry-running, and not actually updating.
@@ -127,6 +129,19 @@ class Assign_Defaults_Command {
 		}
 
 		unset( $args_assoc['dry-run'] );
+
+		$query_args = [];
+
+		if ( isset( $args_assoc['post_type'] ) ) {
+			$query_args['post_type'] = explode( ',', $args_assoc['post_type'] );
+			$query_args['post_type'] = array_intersect( $query_args['post_type'], $supported_post_types );
+		} else {
+			$query_args['post_type'] = $supported_post_types;
+		}
+
+		if ( empty( $query_args['post_type'] ) ) {
+			WP_CLI::error( 'The specified post types are not supported by Utility Taxonomy.' );
+		}
 
 		$query             = $this->get_query();
 		$this->found_posts = absint( $query->found_posts );

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -87,7 +87,7 @@ class Assign_Defaults_Command {
 	 *
 	 * @return void
 	 */
-	protected function process( WP_Post $post ) {
+	protected function process( WP_Post $post ) : void {
 		$term_ids = HMUT\get_post_default_term_ids( $post->ID );
 
 		if ( empty( $term_ids ) ) {

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * HM Utility Taxonomy CLI: Assign default terms to existing published posts
+ */
+
+declare( strict_types=1 );
+
+namespace HM\Utility_Taxonomy\CLI;
+
+use WP_CLI;
+use WP_Post;
+use WP_Query;
+
+/**
+ * Assign default terms
+ */
+class Assign_Defaults_Command {
+	/**
+	 * Number of found posts
+	 *
+	 * @var int
+	 */
+	protected $found_posts = 0;
+
+	/**
+	 * Maximum number of pages
+	 *
+	 * @var int
+	 */
+	protected $max_pages = 0;
+
+	/**
+	 * Current paged number
+	 *
+	 * @var int
+	 */
+	protected $paged = 1;
+
+	/**
+	 * Default posts per page
+	 *
+	 * @var int
+	 */
+	protected $posts_per_page = 100;
+
+	/**
+	 * Used to check whether we're dry-running or not
+	 *
+	 * @var bool
+	 */
+	protected $is_dry_running = false;
+
+	/**
+	 * Process post
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return void
+	 */
+	protected function process( WP_Post $post ) {}
+
+	/**
+	 * Get query
+	 *
+	 * @return WP_Query
+	 */
+	protected function get_query() : WP_Query {
+		$query_args = [
+			'paged'          => $this->paged,
+			'post_status'    => 'publish',
+			'post_type'      => 'post',
+			'posts_per_page' => $this->posts_per_page,
+		];
+
+		$query = new WP_Query( $query_args );
+
+		return $query;
+	}
+
+	/**
+	 * Assign default terms to existing posts
+	 *
+	 * This assign default terms from the utility taxonomy to published posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Run the entire operation and show report, but don't save changes to the database.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp hm-utility-taxonomy assign-defaults --dry-run
+	 * wp hm-utility-taxonomy assign-defaults
+	 *
+	 * @param array $args       Positional arguments passed to the command.
+	 * @param array $args_assoc Associative arguments passed to the command.
+	 *
+	 * @return void
+	 */
+	public function __invoke( array $args, array $args_assoc ) : void {
+		// Indicate that we're dry-running, and not actually updating.
+		if ( isset( $args_assoc['dry-run'] ) && (bool) $args_assoc['dry-run'] === true ) {
+			$this->is_dry_running = true;
+		}
+
+		$query             = $this->get_query();
+		$this->found_posts = absint( $query->found_posts );
+		$this->max_pages   = $query->max_num_pages;
+
+		if ( empty( $this->found_posts ) ) {
+			WP_CLI::log( 'No Posts Found.' );
+			return;
+		}
+
+		WP_CLI::log(
+			sprintf(
+				'Found %s. Beginning to %s.',
+				// translators: %s: Number of items found.
+				sprintf( _n( '%s item', '%s items', $this->found_posts ), $this->found_posts ),
+				$this->is_dry_running ? 'perform dry run' : 'assign default terms'
+			)
+		);
+
+		do {
+			if ( $query->query_vars['paged'] !== $this->paged ) {
+				$query = $this->get_query();
+			}
+
+			array_walk( $query->posts, [ $this, 'process' ] );
+
+			$this->paged ++;
+		} while ( $this->paged <= $this->max_pages );
+	}
+}

--- a/inc/cli/class-assign-defaults-command.php
+++ b/inc/cli/class-assign-defaults-command.php
@@ -14,10 +14,14 @@ use WP_Query;
 
 /**
  * Assign default terms
+ *
+ * @since 1.4.0
  */
 class Assign_Defaults_Command {
 	/**
 	 * Number of found posts
+	 *
+	 * @since 1.4.0
 	 *
 	 * @var int
 	 */
@@ -26,12 +30,16 @@ class Assign_Defaults_Command {
 	/**
 	 * Maximum number of pages
 	 *
+	 * @since 1.4.0
+	 *
 	 * @var int
 	 */
 	protected $max_pages = 0;
 
 	/**
 	 * Current paged number
+	 *
+	 * @since 1.4.0
 	 *
 	 * @var int
 	 */
@@ -40,6 +48,8 @@ class Assign_Defaults_Command {
 	/**
 	 * Default posts per page
 	 *
+	 * @since 1.4.0
+	 *
 	 * @var int
 	 */
 	protected $posts_per_page = 100;
@@ -47,12 +57,16 @@ class Assign_Defaults_Command {
 	/**
 	 * Used to check whether we're dry-running or not
 	 *
+	 * @since 1.4.0
+	 *
 	 * @var bool
 	 */
 	protected $is_dry_running = false;
 
 	/**
 	 * Map term IDs to term names
+	 *
+	 * @since 1.4.0
 	 *
 	 * @param array $term_ids Array of term IDs.
 	 *
@@ -66,6 +80,8 @@ class Assign_Defaults_Command {
 
 	/**
 	 * Process post
+	 *
+	 * @since 1.4.0
 	 *
 	 * @param WP_Post $post Post object.
 	 *
@@ -95,6 +111,8 @@ class Assign_Defaults_Command {
 	/**
 	 * Get query
 	 *
+	 * @since 1.4.0
+	 *
 	 * @param array $args Array of query arguments to pass to WP_Query.
 	 *
 	 * @return WP_Query
@@ -113,6 +131,8 @@ class Assign_Defaults_Command {
 
 	/**
 	 * Get supported post types
+	 *
+	 * @since 1.4.0
 	 *
 	 * @return array|null Array of supported post type names. NULL otherwise.
 	 */
@@ -152,6 +172,8 @@ class Assign_Defaults_Command {
 	 *
 	 *     # Limit operation to draft posts & pages only
 	 *     $ wp hm-utility-taxonomy assign-defaults --post_type=page,post --post_status=draft
+	 *
+	 * @since 1.4.0
 	 *
 	 * @param array $args       Positional arguments passed to the command.
 	 * @param array $args_assoc Associative arguments passed to the command.

--- a/inc/cli/namespace.php
+++ b/inc/cli/namespace.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * HM Utility Taxonomy CLI
+ */
+
+declare( strict_types=1 );
+
+namespace HM\Utility_Taxonomy\CLI;
+
+use WP_CLI;
+
+/**
+ * CLI bootstrapper
+ *
+ * @return void
+ */
+function bootstrap(): void {
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+		return;
+	}
+
+	require_once __DIR__ . '/class-assign-defaults-command.php';
+
+	add_action( 'init', __NAMESPACE__ . '\\register_commands' );
+}
+
+/**
+ * Register CLI commands
+ *
+ * @return void
+ */
+function register_commands(): void {
+	WP_CLI::add_command( 'hm-utility-taxonomy assign-defaults', __NAMESPACE__ . '\\Assign_Defaults_Command' );
+}

--- a/inc/cli/namespace.php
+++ b/inc/cli/namespace.php
@@ -12,6 +12,8 @@ use WP_CLI;
 /**
  * CLI bootstrapper
  *
+ * @since 1.4.0
+ *
  * @return void
  */
 function bootstrap(): void {
@@ -26,6 +28,8 @@ function bootstrap(): void {
 
 /**
  * Register CLI commands
+ *
+ * @since 1.4.0
  *
  * @return void
  */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -126,7 +126,7 @@ function enqueue_editor_assets() : void {
 			'wp-plugins',
 			'wp-url',
 		],
-		'1.3.0',
+		'1.4.0',
 		true
 	);
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,6 +17,8 @@ const TAXONOMY = 'hm-utility';
  * @return void
  */
 function bootstrap() : void {
+	CLI\bootstrap();
+
 	add_action( 'init', __NAMESPACE__ . '\\register_tax' );
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_assets' );
 	add_action( 'save_post', __NAMESPACE__ . '\\set_default_post_terms' );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -13,6 +13,7 @@ const TAXONOMY = 'hm-utility';
  * Bootstrapper
  *
  * @since 1.0.0
+ * @since 1.4.0 Bootstrap CLI.
  *
  * @return void
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanmade/utility-taxonomy",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "A hidden taxonomy, used for filtering of posts/pages etc. in a way that is more performant than using the likes of post meta.",
   "private": true,
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: A hidden taxonomy, used for filtering of posts/pages etc. in a way that is more performant than using the likes of post meta.
  * Author: Human Made
  * Author URI: https://humanmade.com
- * Version: 1.3.1
+ * Version: 1.4.0
  */
 
 namespace HM\Utility_Taxonomy;

--- a/plugin.php
+++ b/plugin.php
@@ -10,6 +10,7 @@
 
 namespace HM\Utility_Taxonomy;
 
+require_once __DIR__ . '/inc/cli/namespace.php';
 require_once __DIR__ . '/inc/namespace.php';
 
 bootstrap();


### PR DESCRIPTION
This PR introduces CLI command to assign default terms as defined in the options:

```
wp hm-utility-taxonomy assign-defaults
```