### PR TITLE
Fix checking create term response body for existing term error.

### DIFF
--- a/assets/src/components/with-term/index.js
+++ b/assets/src/components/with-term/index.js
@@ -32,9 +32,10 @@ export default function withTerm() {
 
 			useEffect( () => {
 				createTerm( taxonomy, label, value )
-					.catch( error => {
+					.catch( async response => {
+						const error = await response.json();
 						if ( error.code !== 'term_exists' ) {
-							return Promise.reject( error );
+							return Promise.reject( response );
 						}
 
 						return searchTerms( taxonomy, value ).then( terms => {


### PR DESCRIPTION
When the  promise is rejected the response object is passed, not the body contents, so the body needs to be parsed as JSON to check if the error is because the term exists. Fixes #13.

This might not be the best way to do this, but it worked for me.