### PR TITLE
Fix withTerm HOC error handling

### DIFF
--- a/assets/src/components/with-term/index.js
+++ b/assets/src/components/with-term/index.js
@@ -32,10 +32,9 @@ export default function withTerm() {
 
 			useEffect( () => {
 				createTerm( taxonomy, label, value )
-					.catch( async response => {
-						const error = await response.json();
+					.catch( error => {
 						if ( error.code !== 'term_exists' ) {
-							return Promise.reject( response );
+							return Promise.reject( error );
 						}
 
 						return searchTerms( taxonomy, value ).then( terms => {

--- a/assets/src/components/with-term/index.js
+++ b/assets/src/components/with-term/index.js
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 export function searchTerms( taxonomy, slug ) {
 	return apiFetch( {
+		parse: true,
 		path: addQueryArgs( `/wp/v2/${ taxonomy }`, {
 			slug,
 			_fields: 'id,name,slug',
@@ -16,6 +17,7 @@ export function searchTerms( taxonomy, slug ) {
 export function createTerm( taxonomy, name, slug ) {
 	return apiFetch( {
 		method: 'POST',
+		parse: true,
 		path: `/wp/v2/${ taxonomy }`,
 		data: {
 			name,


### PR DESCRIPTION
This PR fixes the issue with error handling in `withTerm` HOC by specifically enabling the `parse` option in `apiFetch` calls. This ensures that we get consistent result, which is a  [parsed response](https://github.com/WordPress/gutenberg/tree/af1ed5de38ed54f778608d722e3294669336a7e1/packages/api-fetch#parse-boolean-default-true).