### PR TITLE
#22 Fix Uncaught rejected promise

### DIFF
--- a/assets/src/components/with-term/index.js
+++ b/assets/src/components/with-term/index.js
@@ -46,11 +46,7 @@ export default function withTerm() {
 
 					return searchTerms( taxonomy, value ).then( searchTermsResponse => {
 						if ( searchTermsResponse instanceof Response ) {
-							searchTermsResponse.json().then(
-								terms => {
-									handleSearchTerms( terms );
-								}
-							);
+							searchTermsResponse.json().then( handleSearchTerms );
 						} else {
 							handleSearchTerms( searchTermsResponse );
 						}

--- a/assets/src/components/with-term/index.js
+++ b/assets/src/components/with-term/index.js
@@ -57,7 +57,7 @@ export default function withTerm() {
 					} );
 				}
 
-				function handeNewTerm( newTerm ) {
+				function handleNewTerm( newTerm ) {
 					const { id, name, slug } = newTerm;
 
 					setTerm( {
@@ -70,11 +70,7 @@ export default function withTerm() {
 				createTerm( taxonomy, label, value )
 					.catch( response => {
 						if ( response instanceof Response ) {
-							response.json().then(
-								error => {
-									handleError( error );
-								}
-							);
+							response.json().then( handleError );
 						} else {
 							handleError( response );
 						}
@@ -85,13 +81,9 @@ export default function withTerm() {
 						}
 
 						if ( response instanceof Response ) {
-							response.json().then(
-								newTerm => {
-									handeNewTerm( newTerm );
-								}
-							);
+							response.json().then( handleNewTerm );
 						} else {
-							handeNewTerm( response );
+							handleNewTerm( response );
 						}
 					} );
 			}, [ label, taxonomy, value ] );


### PR DESCRIPTION
Disable parse in apiFetch requests and handle the response object to avoid errors where some other plugins can have a middleware which disables apiFetch parse and therefore results in this plugin throwing an uncaught error.

An example of such a third-party plugin with that behaviour is Yoast SEO Premium which has a createRedirectMiddleware on apiFetch that explicitly intercepts the apiFetch options and changes parse to false because it needs the response object (and not the parsed body of the response) to be able to check its headers and do some extra action if a specific Yoast header is found. Yoast SEO Premium version 18.5 has comments that document exactly what this paragraph says in a file titled "assets/js/dist/wp-seo-premium-redirect-notifications-1850.min.js" (recent versions seem to have those comments removed).

The Yoast code does return the parsed body of the response but if its middleware is executed first then the last middleware which in investigations could be the default WordPress ones will attempt to parse the response body but first checks if parse is true in options. Since it was set to false then the response object will be returned see [here](https://github.com/WordPress/gutenberg/blob/57fe11888c7939cd751ea3107675936e448fe760/packages/api-fetch/src/utils/response.js#L74).

To avoid such behaviour of third-party plugin middleware breaking this plugin, the plugin can just expect the response object in the apiFetch calls and then parses the body of the response.

The proposed solution has been implemented in this PR. #22 initiated the investigation of this.