### PR TITLE
Release v1.4.4

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -126,7 +126,7 @@ function enqueue_editor_assets() : void {
 			'wp-plugins',
 			'wp-url',
 		],
-		'1.4.0',
+		'1.4.4',
 		true
 	);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@humanmade/utility-taxonomy",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@humanmade/utility-taxonomy",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@humanmade/eslint-config": "^1.1.1",
@@ -6570,8 +6570,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@humanmade/eslint-config/-/eslint-config-1.1.1.tgz",
       "integrity": "sha512-oaTVyoTF7jmS9dQ9mIQ48vANHOYiDg+g6O8t+2eN7arzgsPzrfWYJZPsLmmCPZRRXns7WZGVfJbS6VG3P0iTcg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/eslint": {
       "version": "7.2.6",
@@ -6801,15 +6800,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.2.1.tgz",
       "integrity": "sha512-Zj1z6AyS+vqV6Hfi7ngCjFGdHV5EwZNIHo6QfFTNe9PyW+zBU1zJ9BiOW1pmUEq950RC4+Dym6flyA/61/vhyw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.7.0.tgz",
       "integrity": "sha512-yR+rSyfHKfevW84vKBOERpjEslD/o00CaYMftywVYOjsOQ8GLS6xv/VgDcpQ8JomJ9eRRInLRpeGKTM3lOa4xQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wordpress/babel-preset-default": {
       "version": "4.20.0",
@@ -6887,8 +6884,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -6906,8 +6902,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -7667,8 +7662,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-sort-destructure-keys": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanmade/utility-taxonomy",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A hidden taxonomy, used for filtering of posts/pages etc. in a way that is more performant than using the likes of post meta.",
   "private": true,
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
  * Description: A hidden taxonomy, used for filtering of posts/pages etc. in a way that is more performant than using the likes of post meta.
  * Author: Human Made
  * Author URI: https://humanmade.com
- * Version: 1.4.3
+ * Version: 1.4.4
  */
 
 namespace HM\Utility_Taxonomy;


### PR DESCRIPTION
This is necessary because version 1.4.3 was released without updating ./inc/namespace.php therefore users could (and were in some instances) get an older script instead of the latest one due to version number in wp_enqueue_script not being updated.

Documentation around releases has been updated in #25 and #26 to make sure that it's explicit that the version in ./inc/namespace.php should also be updated when creating a release PR.